### PR TITLE
Fix multiple volume binding not working [Fixes #3]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,58 @@
 /tmp/
 /.idea
 
+*.gem
+*.rbc
+/.config
+/InstalledFiles
+/pkg/
+/spec/reports/
+/spec/examples.txt
+/test/tmp/
+/test/version_tmp/
+/tmp/
+
+# Used by dotenv library to load environment variables.
+# .env
+
+## Specific to RubyMotion:
+.dat*
+.repl_history
+build/
+*.bridgesupport
+build-iPhoneOS/
+build-iPhoneSimulator/
+
+# Ignore Byebug/Bash/etc command history file.
+/.*_hist*
+
+# Ignore mac .DS_Store files
+.DS_Store
+
+## Specific to RubyMotion (use of CocoaPods):
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# vendor/Pods/
+
+## Documentation cache and generated files:
+/.yardoc/
+/_yardoc/
+/doc/
+/rdoc/
+
+## Environment normalization:
+/.bundle/
+/vendor/bundle
+/lib/bundler/man/
+
+# for a library or gem, you might want to ignore these files since the code is
+# intended to run in multiple environments; otherwise, check them in:
+Gemfile.lock
+.ruby-version
+.ruby-gemset
+
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+.rvmrc

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,0 +1,30 @@
+# 1: Use ruby 2.3.3 as base:
+FROM ruby:2.3.3
+
+# 2: We'll set this gem path as the working directory
+WORKDIR /usr/src/lib
+
+# 3: We'll set the working dir as HOME and add the app's binaries path to $PATH:
+ENV HOME=/usr/src/lib PATH=/usr/src/lib/bin:$PATH
+
+# 4: Install docker - we'll need the client to run docker commands on the host engine, by mounting
+# the host docker service's socket.
+# Ripped off from https://hub.docker.com/_/docker Dockerfiles:
+RUN set -ex && \
+    export DOCKER_BUCKET=get.docker.com && \
+    export DOCKER_VERSION=17.03.1-ce && \
+    export DOCKER_SHA256=820d13b5699b5df63f7032c8517a5f118a44e2be548dd03271a86656a544af55 && \
+    curl -fSL "https://${DOCKER_BUCKET}/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz" -o docker.tgz && \
+    echo "${DOCKER_SHA256} *docker.tgz" | sha256sum -c - && \
+    tar -xzvf docker.tgz && \
+    mv docker/* /usr/local/bin/ && \
+    rmdir docker && \
+    rm docker.tgz
+
+# 5: Install required gems:
+ADD Gemfile docker.gemspec /usr/src/lib/
+ADD lib/docker/version.rb /usr/src/lib/lib/docker/
+RUN gem install guard && bundle install
+
+# 6: Set the default command:
+CMD ["guard"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '2.1'
+
+services:
+
+  lib:
+    image: xeger/docker-gem:development
+    build:
+      context: .
+      dockerfile: dev.Dockerfile
+
+    volumes:
+      # Mount our app code directory (".") into our app containers at the `/usr/src/lib` folder:
+      - .:/usr/src/lib
+
+      # Add the docker socket to enable docker in docker:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+    # Keep the stdin open, so we can attach to our app container's process
+    # and do things such as byebug, etc:
+    stdin_open: true
+
+    # Enable sending signals (CTRL+C, CTRL+P + CTRL+Q) into the container:
+    tty: true
+
+    # The command:
+    command: guard

--- a/docker.gemspec
+++ b/docker.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/xeger/docker"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features|dev\.Dockerfile|docker-compose.yml)/}) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]

--- a/lib/docker.rb
+++ b/lib/docker.rb
@@ -2,6 +2,7 @@ require_relative 'docker/version'
 require_relative 'docker/error'
 require_relative 'docker/asset'
 require_relative 'docker/container'
+require_relative 'docker/cli'
 require_relative 'docker/session'
 
 module Docker

--- a/lib/docker/cli.rb
+++ b/lib/docker/cli.rb
@@ -1,0 +1,62 @@
+module Docker
+  # Docker command-line parameter generator.
+  # This is a modified version of Backticks::CLI::Getopt, made specially for converting ruby objects
+  # into Docker CLI opts.
+  module CLI
+    # Translate a series Ruby positional and keyword arguments into Docker command-
+    # parameters consisting of words and options.
+    #
+    # Each positional argument can be a Hash, an Array, or another object.
+    # They are handled as follows:
+    #  - Hash is translated to a sequence of options; see #options
+    #  - Array is appended to the command line as a sequence of words
+    #  - other objects are turned into a string with #to_s and appended to the command line as a
+    #    single word
+    #
+    # @return [Array] list of String words and options
+    #
+    # @example recursively find all text files
+    #   parameters('docker', 'run', 'hello_world')
+    #
+    # @example run & remove docker hello world
+    #   parameters('docker', 'run', rm: true, 'hello_world')
+    module Getopt
+      def self.parameters(*sugar)
+        sugar.each_with_object [] do |item, argv|
+          argv.concat extract_parameter(item)
+        end
+      end
+
+      def self.extract_parameter(item)
+        return item.map(&:to_s) if item.is_a? Array
+        return options(item) if item.is_a? Hash
+        [item.to_s]
+      end
+
+      def self.options(kwargs = {})
+        # Transform opts into golang flags-style command line parameters;
+        # append them to the command.
+        kwargs.map { |kw, arg| convert_option kw, arg }.compact.flatten
+      end
+
+      def self.convert_option(option_name, option_value)
+        flag = (option_name.length == 1) ? "-#{option_name}" : "--#{option_name}"
+        return [flag] if option_value == true
+        return process_list_option flag, option_value if option_value.is_a? Array
+        return process_non_null_option flag, option_value if option_value
+      end
+
+      def self.process_list_option(flag, option_value)
+        option_value.map do |value_item|
+          process_non_null_option flag, value_item if value_item
+        end.compact.flatten
+      end
+
+      def self.process_non_null_option(flag, option_value)
+        is_long_flag = flag[0..1] == '--'
+        return "#{flag}=#{option_value}" if is_long_flag
+        [flag, option_value.to_s]
+      end
+    end
+  end
+end

--- a/lib/docker/session.rb
+++ b/lib/docker/session.rb
@@ -23,7 +23,7 @@ module Docker
     # Hint that we are able to parse ps output
     PS_HEADER = /ID\s+IMAGE\s+COMMAND\s+CREATED\s+STATUS\s+PORTS\s+NAMES$/
 
-    def initialize(shell=Backticks::Runner.new, host:ENV['DOCKER_HOST'])
+    def initialize(shell=Backticks::Runner.new(cli: Docker::CLI::Getopt), host:ENV['DOCKER_HOST'])
       @host = host
       @shell = shell
     end

--- a/spec/docker/cli/getopt_spec.rb
+++ b/spec/docker/cli/getopt_spec.rb
@@ -1,0 +1,104 @@
+describe Docker::CLI::Getopt do
+  subject { described_class }
+
+  describe '.parameters' do
+    context 'when given an list of strings' do
+      let(:test_parameters) { %w(docker run hello_world) }
+
+      it 'returns the given parameters as it is' do
+        expect(subject.parameters(*test_parameters)).to eq test_parameters
+      end
+    end
+
+    context 'when one of the given params is an array' do
+      let(:test_parameters) { ['docker', 'run', ['hello_world', '-f', 'json']] }
+
+      it 'returns the given parameters, but flattened' do
+        expect(subject.parameters(*test_parameters)).to eq %w(docker run hello_world -f json)
+      end
+    end
+
+    context 'when one of the given params is an array' do
+      let(:test_options) { { rm: true } }
+      let(:test_parameters) { ['docker', 'run', test_options, 'hello_world'] }
+
+      it 'returns a list of the given parameters, with the expected options/flags parsed in' do
+        expect(subject.parameters(*test_parameters)).to eq %w(docker run --rm hello_world)
+      end
+    end
+  end
+
+  describe '.options' do
+    context 'when given compact options (i.e. -v, -e)' do
+      context 'when given boolean options' do
+        let(:test_options) { { P: true, t: false } }
+
+        it 'emits flags for options having a ''true'' value' do
+          expect(subject.options(test_options)).to include '-P'
+        end
+
+        it 'omits flags for options having a ''false'' value' do
+          expect(subject.options(test_options)).not_to include '-t'
+        end
+      end
+
+      context 'when given an array/list option' do
+        let :test_options do
+          { v: ['/some/path:/path_on_container', '/var/run/docker.sock:/var/run/docker.sock'] }
+        end
+
+        it 'emits a list of alternating flag & value for each option item' do
+          expect(subject.options(test_options)).to eq [
+            '-v',
+            '/some/path:/path_on_container',
+            '-v',
+            '/var/run/docker.sock:/var/run/docker.sock'
+          ]
+        end
+      end
+
+      context 'when given a string-ish object option' do
+        let(:test_options) { { u: 'vovimayhem' } }
+
+        it 'emits a list of alternating flag & value for the option' do
+          expect(subject.options(test_options)).to eq %w(-u vovimayhem)
+        end
+      end
+    end
+
+    context 'when given long options (i.e. --volume, --env)' do
+      context 'when given boolean options' do
+        let(:test_options) { { rm: true, tty: false } }
+
+        it 'emits flags for options having a ''true'' value' do
+          expect(subject.options(test_options)).to include '--rm'
+        end
+
+        it 'omits flags for options having a ''false'' value' do
+          expect(subject.options(test_options)).not_to include '--tty'
+        end
+      end
+
+      context 'when given an array/list option' do
+        let :test_options do
+          { volume: ['/some/path:/path_on_container', '/var/run/docker.sock:/var/run/docker.sock'] }
+        end
+
+        it 'emits a list of ''--flag=value'' for each option item' do
+          expect(subject.options(test_options)).to eq [
+            '--volume=/some/path:/path_on_container',
+            '--volume=/var/run/docker.sock:/var/run/docker.sock'
+          ]
+        end
+      end
+
+      context 'when given a string-ish object option' do
+        let(:test_options) { { user: 'vovimayhem' } }
+
+        it 'emits a ''--flag=value'' for the option' do
+          expect(subject.options(test_options)).to eq ['--user=vovimayhem']
+        end
+      end
+    end
+  end
+end

--- a/spec/docker/session_spec.rb
+++ b/spec/docker/session_spec.rb
@@ -56,6 +56,15 @@ describe Docker::Session do
       output = subject.run('busybox', '/bin/sh', '-c', 'echo "hello world"')
       expect(output).to match(/hello world/)
     end
+
+    context 'with multiple volumes' do
+      it 'accepts multiple volumes as options' do
+        output = subject.run('busybox', '/bin/sh', '-c', 'echo "hello world"', {
+          volume: ['/tmp:/foo', '/tmp:/bar']
+        })
+        expect(output).to match(/hello world/)
+      end
+    end
   end
 
   describe '#start' do


### PR DESCRIPTION
# What does this PR do?

Addresses #3, fixing the CLI opt interpretation to allow array opts, and allowing running containers with multiple volume bindings.

* Add git ignore rules to ignore development artifacts
* Add dockerfile & compose to develop the gem using Docker
* Add example testing the container run with multiple volume bindings
* Add & use a custom CLI Getopt module based on `Backticks::CLI::Getopt` to properly process list opts.