### PR TITLE
Ability to capture stdout I/O stream

### DIFF
--- a/docker.gemspec
+++ b/docker.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "backticks", "~> 0.3"
+  spec.add_dependency "backticks", "~> 1.0.0"
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/docker/session.rb
+++ b/lib/docker/session.rb
@@ -113,7 +113,7 @@ module Docker
             tty:false,
             user:nil,
             volume:[],
-            volumes_from:nil)
+            volumes_from:nil, &block)
 
       cmd = []
 
@@ -137,7 +137,7 @@ module Docker
       cmd.concat(command_and_args)
 
       # return the output of `docker run` minus extra whitespace
-      run!('run', *cmd).strip
+      run!('run', *cmd, &block).strip
     end
 
     # Remove a container.
@@ -199,9 +199,12 @@ module Docker
     #   Backticks::Runner#command
     # @return [String] output of the command
     # @raise [RuntimeError] if command fails
-    def run!(*args)
+    def run!(*args, &block)
       # STDERR.puts "+ " + (['docker'] + args).inspect
-      cmd = @shell.run('docker', *args).join
+      cmd = @shell.run('docker', *args)
+      cmd.tap(&block) if block_given?
+      cmd.join
+
       status, out, err = cmd.status, cmd.captured_output, cmd.captured_error
       status.success? || raise(Error.new(args.first, status, err))
       out


### PR DESCRIPTION
# What does this PR do?

Addresses #5 by adding the ability to send a block to `Docker::Session#run`, so the block receives the I/O stream to `STDOUT` when the container emits output.

* Updates the required `backticks` gem version to ~> 1.0.0
* Changes to `Docker::Session#run` to receive a block, tapping into the backticks command run.